### PR TITLE
Removed dashes from module difficulty tag on review test page

### DIFF
--- a/sat-practice-app/src/app/review-test/page.jsx
+++ b/sat-practice-app/src/app/review-test/page.jsx
@@ -475,7 +475,7 @@ function ReviewTestContent() {
                   {questions[selectedQuestion].domainName} - {questions[selectedQuestion].subcategoryName}
                   {questions[selectedQuestion].moduleNumber === 2 && (
                     <span className="module-tag">
-                      {questions[selectedQuestion].isHarderModule ? ' - Higher Difficulty' : ' - Lower Difficulty'}
+                      {questions[selectedQuestion].isHarderModule ? 'Higher Difficulty' : 'Lower Difficulty'}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
Simple change that just changed the styling of the little tag to not include a hyphen in it "- Lower Difficulty" -> "Lower Difficulty". See image.
<img width="1728" height="1117" alt="Screenshot 2025-08-06 at 11 26 42 PM" src="https://github.com/user-attachments/assets/d2ab3934-f042-4f40-a794-1f940316946e" />
